### PR TITLE
feat: add get films by route

### DIFF
--- a/router.js
+++ b/router.js
@@ -23,6 +23,7 @@ module.exports = function(app) {
   app.patch('/api/films/:id',requireAuth,Film.patchFilm);
   app.delete('/api/films/:id',requireAuth,Film.deleteFilm);
   app.get('/api/films/',requireAuth,Film.getFilm);
+  app.get('/api/films/:id',requireAuth,Film.getFilm);
 
   app.get('/api/accounts/:id',Accounts.getAccounts);
   app.get('/api/accounts/',Accounts.getAccounts);


### PR DESCRIPTION
In my exercises I was not able to call the route /api/films/:id. So I realized that it was missing from routes.js. This way the problem was solved.